### PR TITLE
import order bug fix

### DIFF
--- a/YOLO_face_tf.py
+++ b/YOLO_face_tf.py
@@ -1,6 +1,6 @@
 import numpy as np
-import tensorflow as tf
 import cv2
+import tensorflow as tf
 import time
 import sys
 

--- a/YOLO_small_tf.py
+++ b/YOLO_small_tf.py
@@ -1,6 +1,6 @@
 import numpy as np
-import tensorflow as tf
 import cv2
+import tensorflow as tf
 import time
 import sys
 

--- a/YOLO_tiny_tf.py
+++ b/YOLO_tiny_tf.py
@@ -1,6 +1,6 @@
 import numpy as np
-import tensorflow as tf
 import cv2
+import tensorflow as tf
 import time
 import sys
 


### PR DESCRIPTION
the order of import cause different cv2.imread() result, I don't know
reason. In current order, cv2.imread() returns None.
But after change the order of "import tensorflow as tf" and "import
cv2", the function works correctly.